### PR TITLE
Added columns for video and vimeo links

### DIFF
--- a/src/components/RichTextContentful.js
+++ b/src/components/RichTextContentful.js
@@ -95,11 +95,19 @@ const options = (pr, pl, sm = '12', md = '8', lg = '8') => {
         })
 
         if (videoLink) {
-          return <Video src={videoLink} />
+          return (
+            <Column>
+              <Video src={videoLink} />
+            </Column>
+          )
         }
 
         if (vimeoLink) {
-          return <EmbedPlayer src={vimeoLink} bg="transparent" />
+          return (
+            <Column>
+              <EmbedPlayer src={vimeoLink} bg="transparent" />
+            </Column>
+          )
         }
 
         return (


### PR DESCRIPTION
Fix for this task: https://app.asana.com/0/1128949280388570/1163489482482321

Videos and vimeo links wasn't wrapped in columns which made them wider than the rest of content.

Problem can be seen here:
https://www.strateg.se/work/corona-crisis-comms 
https://www.strateg.se/work/sos-alarm 